### PR TITLE
[ENHANCE] Backward Support for Ruby

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ language: ruby
 matrix:
   include:
     - rvm: ruby-head
+    - rvm: 2.1.10
+    - rvm: 2.2.8
     - rvm: 2.4.1
     - rvm: 2.4.0
     - rvm: 2.3.4

--- a/hm.gemspec
+++ b/hm.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.files = `git ls-files lib LICENSE.txt *.md`.split($RS)
   s.require_paths = ["lib"]
 
-  s.required_ruby_version = '>= 2.3.0'
+  s.required_ruby_version = '>= 2.1.0'
 
   s.add_development_dependency 'yard'
   unless RUBY_ENGINE == 'jruby'

--- a/lib/hm.rb
+++ b/lib/hm.rb
@@ -476,7 +476,7 @@ class Hm
 end
 
 require_relative 'hm/algo'
-require_relative 'patch/dig'
+require_relative 'hm/dig'
 
 # Shortcut for {Hm}.new
 def Hm(hash) # rubocop:disable Naming/MethodName

--- a/lib/hm.rb
+++ b/lib/hm.rb
@@ -476,6 +476,7 @@ class Hm
 end
 
 require_relative 'hm/algo'
+require_relative 'patch/dig'
 
 # Shortcut for {Hm}.new
 def Hm(hash) # rubocop:disable Naming/MethodName

--- a/lib/hm/algo.rb
+++ b/lib/hm/algo.rb
@@ -60,7 +60,7 @@ class Hm
     end
 
     def visit(what, rest, path = [], not_found: ->(*) {}, &found)
-      what.respond_to?(:dig) or fail TypeError, "#{what.class} is not diggable"
+      Dig.diggable?(what) or fail TypeError, "#{what.class} is not diggable"
 
       key, *rst = rest
       if key == WILDCARD
@@ -73,7 +73,7 @@ class Hm
     def visit_all(what, path = [], &block)
       robust_enumerator(what).each do |key, val|
         yield(what, [*path, key], val)
-        visit_all(val, [*path, key], &block) if val.respond_to?(:dig)
+        visit_all(val, [*path, key], &block) if Dig.diggable?(val)
       end
     end
 
@@ -87,7 +87,7 @@ class Hm
     end
 
     def visit_regular(what, key, rest, path, found:, not_found:) # rubocop:disable Metrics/ParameterLists
-      internal = what.dig(key) or return not_found.(what, [*path, key], rest)
+      internal = Hm::Dig.dig(what, key) or return not_found.(what, [*path, key], rest)
       rest.empty? and return found.(what, [*path, key], internal)
       visit(internal, rest, [*path, key], not_found: not_found, &found)
     end

--- a/lib/hm/algo.rb
+++ b/lib/hm/algo.rb
@@ -87,7 +87,7 @@ class Hm
     end
 
     def visit_regular(what, key, rest, path, found:, not_found:) # rubocop:disable Metrics/ParameterLists
-      internal = Hm::Dig.dig(what, key) or return not_found.(what, [*path, key], rest)
+      internal = Dig.dig(what, key) or return not_found.(what, [*path, key], rest)
       rest.empty? and return found.(what, [*path, key], internal)
       visit(internal, rest, [*path, key], not_found: not_found, &found)
     end

--- a/lib/hm/dig.rb
+++ b/lib/hm/dig.rb
@@ -3,12 +3,12 @@ class Hm
     DIGGABLE_CLASSES = [Hash, Array].freeze
 
     def self.dig(what, *keys)
-      if what.respond_to?(:dig)
-        return what.dig(*keys)
-      elsif diggable?(what)
+      return what.dig(*keys) if what.respond_to?(:dig)
+
+      if diggable?(what)
         value = what[keys.shift]
         return value if value.nil? || keys.empty?
-        return self.dig(value, *keys)
+        return dig(value, *keys)
       end
 
       fail TypeError, "#{value.class} is not diggable"

--- a/lib/hm/dig.rb
+++ b/lib/hm/dig.rb
@@ -1,17 +1,16 @@
 class Hm
+  # @private
   module Dig
+    # TODO: Struct/OpenStruct are also diggable in Ruby core, can be added for future implementation
     DIGGABLE_CLASSES = [Hash, Array].freeze
 
     def self.dig(what, *keys)
       return what.dig(*keys) if what.respond_to?(:dig)
 
-      if diggable?(what)
+      if diggable?(what) or fail TypeError, "#{value.class} is not diggable"
         value = what[keys.shift]
-        return value if value.nil? || keys.empty?
-        return dig(value, *keys)
+        (value.nil? || keys.empty?) ? value : dig(value, *keys)
       end
-
-      fail TypeError, "#{value.class} is not diggable"
     end
 
     def self.diggable?(what)

--- a/lib/hm/dig.rb
+++ b/lib/hm/dig.rb
@@ -11,7 +11,6 @@ module RubyDig
   end
 end
 
-if RUBY_VERSION < '2.3'
-  Array.send(:include, RubyDig)
-  Hash.send(:include, RubyDig)
-end
+INCLUDE_CLASSES = [Array, Hash].freeze
+
+INCLUDE_CLASSES.each { |klass| klass.send(:include, RubyDig) unless klass.method_defined?(:dig) }

--- a/lib/hm/dig.rb
+++ b/lib/hm/dig.rb
@@ -1,16 +1,21 @@
-module RubyDig
-  def dig(key, *rest)
-    value = self[key]
-    if value.nil? || rest.empty?
-      value
-    elsif value.respond_to?(:dig)
-      value.dig(*rest)
-    else
+class Hm
+  module Dig
+    DIGGABLE_CLASSES = [Hash, Array].freeze
+
+    def self.dig(what, *keys)
+      if what.respond_to?(:dig)
+        return what.dig(*keys)
+      elsif diggable?(what)
+        value = what[keys.shift]
+        return value if value.nil? || keys.empty?
+        return self.dig(value, *keys)
+      end
+
       fail TypeError, "#{value.class} is not diggable"
+    end
+
+    def self.diggable?(what)
+      DIGGABLE_CLASSES.include?(what.class)
     end
   end
 end
-
-INCLUDE_CLASSES = [Array, Hash].freeze
-
-INCLUDE_CLASSES.each { |klass| klass.send(:include, RubyDig) unless klass.method_defined?(:dig) }

--- a/lib/patch/dig.rb
+++ b/lib/patch/dig.rb
@@ -1,0 +1,17 @@
+module RubyDig
+  def dig(key, *rest)
+    value = self[key]
+    if value.nil? || rest.empty?
+      value
+    elsif value.respond_to?(:dig)
+      value.dig(*rest)
+    else
+      fail TypeError, "#{value.class} is not diggable"
+    end
+  end
+end
+
+if RUBY_VERSION < '2.3'
+  Array.send(:include, RubyDig)
+  Hash.send(:include, RubyDig)
+end


### PR DESCRIPTION
### Objective

Since some people still might be using older Ruby version, I guess support for some older ones might be alright @@?

### Features

- Dig module for supporting backward compatibility `dig` like method
- Allow developers to implement its own `dig` without interfering Core classes.